### PR TITLE
Refs2 acdc integration

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const UploadTypes = require("./lib/utils/UploadTypes");
 const XMLDisplayService = require("./lib/services/XMLDisplayService/XMLDisplayService");
 const utils = require("./lib/utils/CommonUtils");
 const validationUtils = require("./lib/utils/ValidationUtils");
+const versionTransformer = require("./lib/EpiVersionTransformer")
 const constants = require("./lib/constants/constants");
 
 module.exports = {
@@ -26,6 +27,7 @@ module.exports = {
   Languages,
   utils,
   validationUtils,
+  versionTransformer,
   constants,
   XMLDisplayService,
   loadApi: function (apiName) {


### PR DESCRIPTION
for acdc integration.

needs also the PR in leaflet and epi-workspace.

the auth feature result is now relayed to the acdc address defined in the product.

restored control of application back to the DrugDetailsController but:
 - No data is passed back to the DrugDetailsController (this will probably have to be done via event because of the modal), since you are unsure on how to display this. the result is simply written to the console for confirmation.
 - Because of the new way you store data in the batches, and because there is no api to retrieve the latest batch info without knowing what the latest is, the ssi stored on batch creation is the only that will be read. this means that updating the auth feature ssi on a batch level does not work atm